### PR TITLE
chore: data-api-demo to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+- name: data-api-demo
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.9
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
chore: Promote data-api-demo to version 0.0.9